### PR TITLE
10 Add get the oldest olympian endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+group :test do
+  gem 'database_cleaner-active_record'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,10 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    database_cleaner (1.8.3)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
@@ -185,6 +189,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara
+  database_cleaner-active_record
   factory_bot_rails
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ Example successful response:
     ]
 }
 ```
+##### Get Oldest Olympian
+`GET` to `/api/v1/olympians?age=oldest`
+
+Example successful response:
+```
+{
+  "olympians":
+    [
+      {
+        "name": "Julie Brougham",
+        "team": "New Zealand",
+        "age": 62,
+        "sport": "Equestrianism"
+        "total_medals_won": 0
+      }
+    ]
+}
+```
 
 ### Known Issues
 ### Running Tests

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,10 +1,17 @@
 class Api::V1::OlympiansController < ApplicationController
   def index
-    if params[:age]
-      olympians = FormatOlympians.new(Olympian.youngest)
-    else
-      olympians = FormatOlympians.new(Olympian.all)
-    end
+    olympians = check_params(params)
     render json: olympians
   end
+
+  private
+    def check_params(params)
+      if request.query_string.empty?
+        olympians = FormatOlympians.new(Olympian.all)
+      elsif params[:age] == 'youngest'
+        olympians = FormatOlympians.new(Olympian.youngest)
+      elsif params[:age] == 'oldest'
+        olympians = FormatOlympians.new(Olympian.oldest)
+      end
+    end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -14,6 +14,10 @@ class Olympian < ApplicationRecord
     where(age: minimum(:age))
   end
 
+  def self.oldest
+    where(age: maximum(:age))
+  end
+
   def total_medals_won
     self.olympian_events.where.not(medal: 'NA').count
   end

--- a/app/poros/format_olympian.rb
+++ b/app/poros/format_olympian.rb
@@ -1,4 +1,6 @@
 class FormatOlympian
+  attr_reader :name, :team, :age, :sport, :total_medals_won
+
   def initialize(olympian)
     @name = olympian.full_name
     @team = olympian.team.name

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe Olympian, type: :model do
       create(:olympian, :with_olympian_events, olympian_event_count: 1)
 
       expect(Olympian.youngest[0]).to eq(olympian_1)
+    it 'oldest' do
+      create(:olympian, age: 25)
+      oldest_olympian = create(:olympian, age: 46)
+      create(:olympian, age: 32)
+
+      expect(Olympian.oldest[0]).to eq(oldest_olympian)
     end
   end
 

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -39,12 +39,14 @@ RSpec.describe Olympian, type: :model do
   end
 
   describe 'class methods' do
-    it '.youngest' do
-      olympian_1 = create(:olympian, :with_olympian_events, olympian_event_count: 3)
-      create(:olympian, :with_olympian_events, olympian_event_count: 2)
-      create(:olympian, :with_olympian_events, olympian_event_count: 1)
+    it 'youngest' do
+      youngest_olympian = create(:olympian, age: 25)
+      create(:olympian, age: 46)
+      create(:olympian, age: 32)
 
-      expect(Olympian.youngest[0]).to eq(olympian_1)
+      expect(Olympian.youngest[0]).to eq(youngest_olympian)
+    end
+
     it 'oldest' do
       create(:olympian, age: 25)
       oldest_olympian = create(:olympian, age: 46)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -43,7 +43,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/api/v1/olympians_request_spec.rb
+++ b/spec/requests/api/v1/olympians_request_spec.rb
@@ -40,5 +40,29 @@ RSpec.describe 'Olympians API' do
     expect(youngest_olympian[:olympians][0]).to have_key(:age)
     expect(youngest_olympian[:olympians][0]).to have_key(:sport)
     expect(youngest_olympian[:olympians][0]).to have_key(:total_medals_won)
+
+  it 'sends a back the oldest olympian' do
+    get '/api/v1/olympians?age=oldest'
+
+    expect(response).to be_successful
+
+    oldest_res = JSON.parse(response.body, symbolize_names: true)
+
+    oldest_olympian = FormatOlympian.new(Olympian.last)
+
+    expect(oldest_res).to have_key(:olympians)
+    expect(oldest_res[:olympians].count).to eq(1)
+    expect(oldest_res[:olympians]).to be_a(Array)
+    expect(oldest_res[:olympians][0]).to be_a(Hash)
+    expect(oldest_res[:olympians][0]).to have_key(:name)
+    expect(oldest_res[:olympians][0]).to have_key(:team)
+    expect(oldest_res[:olympians][0]).to have_key(:age)
+    expect(oldest_res[:olympians][0]).to have_key(:sport)
+    expect(oldest_res[:olympians][0]).to have_key(:total_medals_won)
+    expect(oldest_res[:olympians][0][:name]).to eq(oldest_olympian.name)
+    expect(oldest_res[:olympians][0][:team]).to eq(oldest_olympian.team)
+    expect(oldest_res[:olympians][0][:age]).to eq(oldest_olympian.age)
+    expect(oldest_res[:olympians][0][:sport]).to eq(oldest_olympian.sport)
+    expect(oldest_res[:olympians][0][:total_medals_won]).to eq(oldest_olympian.total_medals_won)
   end
 end

--- a/spec/requests/api/v1/olympians_request_spec.rb
+++ b/spec/requests/api/v1/olympians_request_spec.rb
@@ -29,17 +29,25 @@ RSpec.describe 'Olympians API' do
 
     expect(response).to be_successful
 
-    youngest_olympian = JSON.parse(response.body, symbolize_names: true)
+    youngest_res = JSON.parse(response.body, symbolize_names: true)
 
-    expect(youngest_olympian).to have_key(:olympians)
-    expect(youngest_olympian[:olympians].count).to eq(1)
-    expect(youngest_olympian[:olympians]).to be_a(Array)
-    expect(youngest_olympian[:olympians][0]).to be_a(Hash)
-    expect(youngest_olympian[:olympians][0]).to have_key(:name)
-    expect(youngest_olympian[:olympians][0]).to have_key(:team)
-    expect(youngest_olympian[:olympians][0]).to have_key(:age)
-    expect(youngest_olympian[:olympians][0]).to have_key(:sport)
-    expect(youngest_olympian[:olympians][0]).to have_key(:total_medals_won)
+    youngest_olympian = FormatOlympian.new(Olympian.first)
+
+    expect(youngest_res).to have_key(:olympians)
+    expect(youngest_res[:olympians].count).to eq(1)
+    expect(youngest_res[:olympians]).to be_a(Array)
+    expect(youngest_res[:olympians][0]).to be_a(Hash)
+    expect(youngest_res[:olympians][0]).to have_key(:name)
+    expect(youngest_res[:olympians][0]).to have_key(:team)
+    expect(youngest_res[:olympians][0]).to have_key(:age)
+    expect(youngest_res[:olympians][0]).to have_key(:sport)
+    expect(youngest_res[:olympians][0]).to have_key(:total_medals_won)
+    expect(youngest_res[:olympians][0][:name]).to eq(youngest_olympian.name)
+    expect(youngest_res[:olympians][0][:team]).to eq(youngest_olympian.team)
+    expect(youngest_res[:olympians][0][:age]).to eq(youngest_olympian.age)
+    expect(youngest_res[:olympians][0][:sport]).to eq(youngest_olympian.sport)
+    expect(youngest_res[:olympians][0][:total_medals_won]).to eq(youngest_olympian.total_medals_won)
+  end
 
   it 'sends a back the oldest olympian' do
     get '/api/v1/olympians?age=oldest'

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,23 @@
+RSpec.configure do |config|
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
+end


### PR DESCRIPTION
### Fixes #10 
## Type of change
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change is a documentation update
## Summary of changes
- Add test for `GET /api/v1/olympians?age=oldest` endpoint
- Add private method and refactor OlympiansController index action
- Add Olympian class method test for self.oldest method
- Add class method self.oldest
- Update README with endpoint information

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [x] :white_square_button: Unit testing
## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing tests pass locally with my changes
